### PR TITLE
Feature/flexible pcr result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## v0.0.3 2021-07-21
+
+- Fix issue with backslashes (issue 52)
+- Bump AWSSDK.S3 from 3.7.1.13 to 3.7.1.15
+- Bump System.IO.Abstractions from 13.2.38 to 13.2.41
+- Bump System.IO.Abstractions.TestingHelpers from 13.2.38 to 13.2.41
+
+## v0.0.2 2021-07-13
+
+- Bump AWSSDK.S3 from 3.7.0.18 to 3.7.1.13
+- Specify endpoint to fix issue 50

--- a/nccid/NCCIDdata.cs
+++ b/nccid/NCCIDdata.cs
@@ -31,8 +31,18 @@ namespace nccid
             this.when = when;
         }
 
-        public static INCCIDdata Make(string centreName, bool pos,DateTime _when,string _pn)
+        public static INCCIDdata Make(string centreName, string pcrpos,DateTime _when,string _pn)
         {
+            bool pos = pcrpos.ToLowerInvariant() switch
+            {
+                "0" => false,
+                "negative" => false,
+
+                "1" => true,
+                "positive" => true,
+
+                _ => throw new ArgumentException($"Invalid PCR test result '{pcrpos}'")
+            };
             if (pos)
                 return new PositiveData(centreName,_when,_pn);
             else return new NegativeData(centreName,_when,_pn);

--- a/nccid/nccidmain.cs
+++ b/nccid/nccidmain.cs
@@ -116,7 +116,7 @@ namespace nccid
             {
                 try
                 {
-                    var datum = INCCIDdata.Make(o.CentreName, csv.GetField<int>("Status") != 0, csv.GetField<DateTime>("Date"),
+                    var datum = INCCIDdata.Make(o.CentreName, csv.GetField<string>("Status"), csv.GetField<DateTime>("Date"),
                         csv.GetField("ID"));
                     var json = datum.ToJson();
                     await using var ms = new MemoryStream(json, false);


### PR DESCRIPTION
- Accept "positive" and "negative" in input CSV as PCR test results, not just "0" and "1"
- Closes #59 